### PR TITLE
#162204328 Add API endpoint to get all red-flag records

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,8 +9,5 @@ app.use(bodyParser.urlencoded({ extended: false }));
 const redFlag = require('./server/routes/red_flags.js');
 app.use('/', redFlag);
 
-if (require.main === module) {
-  app.listen(process.env.PORT || 3000);
-} else {
-  module.exports = app;
-}
+app.listen(process.env.PORT || 3000);
+export default app;

--- a/server/controllers/red_flags.js
+++ b/server/controllers/red_flags.js
@@ -1,11 +1,11 @@
-const helper = require('../helper.js');
-const mockData = require('../mockdata.js');
+import redFlagFilled from '../helper';
+import redFlags from '../mockdata';
 
-exports.createRedFlag = (request, response) => {
-  if (!helper.redFlagFilled(request.body)) {
+export const createRedFlag = (request, response) => {
+  if (!redFlagFilled(request.body)) {
     response.status(422).json({ status: 422, error: 'invalid data' });
   } else {
-    const id = mockData.redFlags.length + 1;
+    const id = redFlags.length + 1;
     const title = request.body.title.trim();
     const dateObj = new Date();
     const createdOn = `${dateObj.getFullYear()} / ${(dateObj.getMonth() + 1)} / ${dateObj.getDate()}`;
@@ -19,7 +19,11 @@ exports.createRedFlag = (request, response) => {
       id, title, createdOn, status, createdBy, type, location, comment,
     };
 
-    mockData.redFlags.push(data);
+    redFlags.push(data);
     response.status(201).json({ status: 201, data: [{ id, message: 'created red-flag record' }] });
   }
+};
+
+export const getRedFlags = (request, response) => {
+  response.status(200).json({ status: 200, data: redFlags });
 };

--- a/server/helper.js
+++ b/server/helper.js
@@ -1,4 +1,5 @@
-exports.redFlagFilled = (obj) => {
+const redFlagFilled = (obj) => {
   if (!obj.title || !obj.comment || !obj.location) return false;
   return true;
 };
+export default redFlagFilled;

--- a/server/mockdata.js
+++ b/server/mockdata.js
@@ -1,4 +1,4 @@
-exports.redFlags = [
+const redFlags = [
   {
     id: 1,
     title: 'Sars beat my boyfriend up',
@@ -9,4 +9,15 @@ exports.redFlags = [
     status: 'new',
     comment: "Sars assaulted my boyfriend at ikeja. We didn't do anything wrong. They illegally searched our phones and computers and we complied. They later requested for money because they saw some foreign contacts on my boyfriend's phone and we refused. Then they seriously beat him up. He is currently at the hospital receiving treatment.",
   },
+  {
+    id: 2,
+    title: 'Waste disposal problems',
+    createdOn: 'Date',
+    createdBy: 1,
+    type: 'red-flag',
+    location: '6.5244° N, 3.3792° E',
+    status: 'Resolved',
+    comment: 'The community trash cans have been full for a few days and no waste disposal agency has been there to empty them. People have resorted to dumping garbage by the roadside and the whole street reeks. Kindly look into this.',
+  },
 ];
+export default redFlags;

--- a/server/routes/red_flags.js
+++ b/server/routes/red_flags.js
@@ -1,9 +1,9 @@
-const express = require('express');
-const controller = require('../../server/controllers/red_flags.js');
+import express from 'express';
+import { createRedFlag, getRedFlags } from '../controllers/red_flags';
 
 const router = express.Router();
 
-// Home page route.
-router.post('/api/v1/red-flags', controller.createRedFlag);
+router.post('/api/v1/red-flags', createRedFlag);
+router.get('/api/v1/red-flags', getRedFlags);
 
 module.exports = router;


### PR DESCRIPTION
### What does this PR do?
Adds an API endpoint for user to get all red-flag records. It returns HTTP 200 status code on success.

### How should this be manually tested?
Send a GET request to `api/v1/red-flags.`

### Screenshots
![get all red-flags](https://user-images.githubusercontent.com/8430993/49028770-759d3380-f1a3-11e8-9b48-d0df303235d2.PNG)
### Pivotal tracker story
https://www.pivotaltracker.com/story/show/162204328