### PR TITLE
#162204594 Add API endpoint to get specific red-flag record

### DIFF
--- a/server/controllers/red_flags.js
+++ b/server/controllers/red_flags.js
@@ -1,4 +1,4 @@
-import redFlagFilled from '../helper';
+import { redFlagFilled, validId, redFlagExists } from '../helper';
 import redFlags from '../mockdata';
 
 export const createRedFlag = (request, response) => {
@@ -26,4 +26,14 @@ export const createRedFlag = (request, response) => {
 
 export const getRedFlags = (request, response) => {
   response.status(200).json({ status: 200, data: redFlags });
+};
+
+export const getSpecificRedFlag = (request, response) => {
+  if (!validId(request.params.id)) {
+    response.status(422).json({ status: 422, error: 'Invalid URL' });
+  } else if (!redFlagExists(request.params.id, redFlags)) {
+    response.status(404).json({ status: 404, error: 'record not found' });
+  } else {
+    response.status(200).json({ status: 200, data: [redFlags[request.params.id - 1]] });
+  }
 };

--- a/server/helper.js
+++ b/server/helper.js
@@ -1,5 +1,8 @@
-const redFlagFilled = (obj) => {
+export const redFlagFilled = (obj) => {
   if (!obj.title || !obj.comment || !obj.location) return false;
   return true;
 };
-export default redFlagFilled;
+
+export const validId = id => (!(Number.isNaN(id)));
+
+export const redFlagExists = (id, redFlags) => (!!(redFlags[id - 1]));

--- a/server/routes/red_flags.js
+++ b/server/routes/red_flags.js
@@ -1,9 +1,10 @@
 import express from 'express';
-import { createRedFlag, getRedFlags } from '../controllers/red_flags';
+import { createRedFlag, getRedFlags, getSpecificRedFlag } from '../controllers/red_flags';
 
 const router = express.Router();
 
 router.post('/api/v1/red-flags', createRedFlag);
 router.get('/api/v1/red-flags', getRedFlags);
+router.get('/api/v1/red-flags/:id', getSpecificRedFlag);
 
 module.exports = router;


### PR DESCRIPTION
### What does this PR do?
Adds an API endpoint for user to get a specific red-flag. It returns HTTP 200 status code on success, 422 for invalid URL and 404 for red-flag not found

### How should this be manually tested?
Send a GET request to `api/v1/red-flags/<id>` where `id` is the id of the red-flag record you want to get

### Screenshots
![specific red flag](https://user-images.githubusercontent.com/8430993/49035889-6bd0fb80-f1b6-11e8-8bae-26f70d01d237.PNG)
### Pivotal tracker story
https://www.pivotaltracker.com/story/show/162204594