### PR TITLE
#162206400 Add API endpoint to update the location of a specific red-flag record

### DIFF
--- a/server/controllers/red_flags.js
+++ b/server/controllers/red_flags.js
@@ -37,3 +37,14 @@ export const getSpecificRedFlag = (request, response) => {
     response.status(200).json({ status: 200, data: [redFlags[request.params.id - 1]] });
   }
 };
+
+export const updateLocation = (request, response) => {
+  if (!validId(request.params.id) || !request.body.location) {
+    response.status(422).json({ status: 422, error: 'Invalid URL' });
+  } else if (!redFlagExists(request.params.id, redFlags)) {
+    response.status(404).json({ status: 404, error: 'record not found' });
+  } else {
+    redFlags[request.params.id - 1].location = request.body.location;
+    response.status(201).json({ status: 201, data: [{ id: request.params.id, message: 'Updated red-flag record’s location' }] });
+  }
+}

--- a/server/routes/red_flags.js
+++ b/server/routes/red_flags.js
@@ -1,10 +1,11 @@
 import express from 'express';
-import { createRedFlag, getRedFlags, getSpecificRedFlag } from '../controllers/red_flags';
+import { createRedFlag, getRedFlags, getSpecificRedFlag, updateLocation } from '../controllers/red_flags';
 
 const router = express.Router();
 
 router.post('/api/v1/red-flags', createRedFlag);
 router.get('/api/v1/red-flags', getRedFlags);
 router.get('/api/v1/red-flags/:id', getSpecificRedFlag);
+router.patch('/api/v1/red-flags/:id/location', updateLocation);
 
 module.exports = router;


### PR DESCRIPTION
### What does this PR do?
Adds an API endpoint for user to edit the location of a specific red-flag record.

### How should this be manually tested?
Send a PATCH request to api/v1/red-flags/<red-flag id>/location with a JSON object of location.

### Screenshots
![edit red flag location](https://user-images.githubusercontent.com/8430993/49094523-c590fe80-f266-11e8-9569-c54a89eabf0c.PNG)
### Pivotal tracker story
https://www.pivotaltracker.com/story/show/162206400