### PR TITLE
#162206606 Add API endpoint to edit the comment of a specific red flag record

### DIFF
--- a/server/controllers/red_flags.js
+++ b/server/controllers/red_flags.js
@@ -47,4 +47,15 @@ export const updateLocation = (request, response) => {
     redFlags[request.params.id - 1].location = request.body.location;
     response.status(201).json({ status: 201, data: [{ id: request.params.id, message: 'Updated red-flag record’s location' }] });
   }
-}
+};
+
+export const updateComment = (request, response) => {
+  if (!validId(request.params.id) || !request.body.comment) {
+    response.status(422).json({ status: 422, error: 'Invalid URL' });
+  } else if (!redFlagExists(request.params.id, redFlags)) {
+    response.status(404).json({ status: 404, error: 'record not found' });
+  } else {
+    redFlags[request.params.id - 1].comment = request.body.comment;
+    response.status(201).json({ status: 201, data: [{ id: request.params.id, message: 'Updated red-flag record’s comment' }] });
+  }
+};

--- a/server/helper.js
+++ b/server/helper.js
@@ -3,6 +3,6 @@ export const redFlagFilled = (obj) => {
   return true;
 };
 
-export const validId = id => (!(Number.isNaN(id)));
+export const validId = id => Number.isInteger(parseInt(id, 10));
 
 export const redFlagExists = (id, redFlags) => (!!(redFlags[id - 1]));

--- a/server/routes/red_flags.js
+++ b/server/routes/red_flags.js
@@ -1,5 +1,7 @@
 import express from 'express';
-import { createRedFlag, getRedFlags, getSpecificRedFlag, updateLocation } from '../controllers/red_flags';
+import {
+  createRedFlag, getRedFlags, getSpecificRedFlag, updateLocation, updateComment,
+} from '../controllers/red_flags';
 
 const router = express.Router();
 
@@ -7,5 +9,6 @@ router.post('/api/v1/red-flags', createRedFlag);
 router.get('/api/v1/red-flags', getRedFlags);
 router.get('/api/v1/red-flags/:id', getSpecificRedFlag);
 router.patch('/api/v1/red-flags/:id/location', updateLocation);
+router.patch('/api/v1/red-flags/:id/comment', updateComment);
 
 module.exports = router;


### PR DESCRIPTION
### What does this PR do?
Adds an API endpoint for user to edit the comment of a specific red-flag record

### How should this be manually tested?
Send a POST request to `api/v1/red-flags/<red-flag id>/comment` with a JSON object of comment

### Screenshots
![edit red flag comment](https://user-images.githubusercontent.com/8430993/49099597-2a058b00-f272-11e8-9c24-9a6a6db0dde1.PNG)

Pivotal tracker story
https://www.pivotaltracker.com/story/show/162206606