### PR TITLE
#162246257 Add API endpoint to delete a red-flag record

### DIFF
--- a/server/controllers/red_flags.js
+++ b/server/controllers/red_flags.js
@@ -59,3 +59,12 @@ export const updateComment = (request, response) => {
     response.status(201).json({ status: 201, data: [{ id: request.params.id, message: 'Updated red-flag record’s comment' }] });
   }
 };
+
+export const deleteRedFlag = (request, response) => {
+  if (!redFlagExists(request.params.id, redFlags)) {
+    response.status(404).json({ status: 404, error: 'record not found' });
+  } else {
+    delete redFlags[request.params.id - 1];
+    response.status(200).json({ status: 200, data: [{ id: request.params.id, message: 'red-flag record has been deleted' }] });
+  }
+};

--- a/server/routes/red_flags.js
+++ b/server/routes/red_flags.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import {
-  createRedFlag, getRedFlags, getSpecificRedFlag, updateLocation, updateComment,
+  createRedFlag, getRedFlags, getSpecificRedFlag, updateLocation, updateComment, deleteRedFlag,
 } from '../controllers/red_flags';
 
 const router = express.Router();
@@ -10,5 +10,6 @@ router.get('/api/v1/red-flags', getRedFlags);
 router.get('/api/v1/red-flags/:id', getSpecificRedFlag);
 router.patch('/api/v1/red-flags/:id/location', updateLocation);
 router.patch('/api/v1/red-flags/:id/comment', updateComment);
+router.delete('/api/v1/red-flags/:id', deleteRedFlag);
 
 module.exports = router;


### PR DESCRIPTION
### What does this PR do?
Adds an API endpoint to delete a red-flag. It returns HTTP 201 status code on success and 404 for record not found.

### How should this be manually tested?
Send a DELETE request to `api/v1/red-flags/<red-flag id>` where `<red-flag id>` is the id of the red flag you want to delete.

### Screenshots
![delete red falg](https://user-images.githubusercontent.com/8430993/49101110-b796aa00-f275-11e8-912c-ce878a5b07e2.PNG)

Pivotal tracker story
https://www.pivotaltracker.com/story/show/162246257