### PR TITLE
#162636997 Add create intervention record endpoint

### DIFF
--- a/server/controllers/records.js
+++ b/server/controllers/records.js
@@ -20,7 +20,8 @@ class Records {
     }
     const title = request.body.title.trim();
     const createdOn = dateString();
-    const type = request.route.path.substr(1);
+    let type = request.route.path.substr(1);
+    if (type === 'interventions') type = 'intervention';
     const location = request.body.location.trim();
     const comment = request.body.comment.trim();
     const images = (request.body.images) ? request.body.images : '';
@@ -31,12 +32,14 @@ class Records {
       title, createdOn, type, location, comment, images, videos, createdBy,
     };
 
+    const message = `Created ${type} record`;
+
     const id = await RecordsModel.createRecord(data);
     return response.status(201).json({
       status: 201,
       data: [{
         id,
-        message: 'created red-flag record',
+        message,
       }],
     });
   }

--- a/server/routes/records.js
+++ b/server/routes/records.js
@@ -10,6 +10,7 @@ import {
 const router = express.Router();
 
 router.post('/red-flags', Records.createRecord);
+router.post('/interventions', Records.createRecord);
 router.get('/red-flags', Records.getRecords);
 router.get('/red-flags/:id', getRecordType, validateUrl, Records.getSpecificRecord);
 router.patch('/red-flags/:id/location', getRecordType, validateUrl, validateRecordType, Records.updateRecord);

--- a/server/spec/routes.spec.js
+++ b/server/spec/routes.spec.js
@@ -109,6 +109,93 @@ describe('Server', () => {
     });
   });
 
+  describe('POST /api/v1/interventions', () => {
+    const data = {
+      title: 'Test intervention record',
+      location: 'Test location',
+      comment: 'Test comment',
+      createdby: 1,
+    };
+    const dataOnlySpaces = {
+      title: '   ',
+      location: '  ',
+      comment: '   ',
+    };
+    const dataNoTitle = {
+      location: 'Test location',
+      comment: 'Test comment',
+    };
+    const dataNoLocation = {
+      title: 'Test intervention',
+      comment: 'Test comment',
+    };
+    const dataNoComment = {
+      title: 'Test intervention',
+      location: 'Test location',
+    };
+
+    it('Should return 201 for content created', async () => {
+      await supertest(appInstance)
+        .post('/api/v1/interventions')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(201);
+        });
+    });
+
+    it('Should return 400 for invalid data', async () => {
+      await supertest(appInstance)
+        .post('/api/v1/interventions')
+        .send()
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+    it('Should return 400 for no title', async () => {
+      await supertest(appInstance)
+        .post('/api/v1/interventions')
+        .send(dataNoTitle)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+    it('Should return 400 for no location', async () => {
+      await supertest(appInstance)
+        .post('/api/v1/interventions')
+        .send(dataNoLocation)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+    it('Should return 400 for no comment', async () => {
+      await supertest(appInstance)
+        .post('/api/v1/interventions')
+        .send(dataNoComment)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+    it('Should return 400 for no invalid data', async () => {
+      await supertest(appInstance)
+        .post('/api/v1/interventions')
+        .send(dataOnlySpaces)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+  });
 
   describe('GET /api/v1/red-flags/:id', () => {
     it('should return 200 for successful request', async () => {


### PR DESCRIPTION
#### What does this PR do?
This PR adds an endpoint for users to create intervention record
#### Description of task to be completed?
* Add create intervention record
* Write tests for the endpoint
#### How can this be manually tested?
* Clone the repository
* Checkout to branch `ft-create-intervention-endpoint-162636997`
* Send a post request to `api/v1/interventions`
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162636997
#### Screenshots (If available)
N/A