### PR TITLE
#162636950 Add API endpoint to get all intervention records

### DIFF
--- a/server/controllers/records.js
+++ b/server/controllers/records.js
@@ -51,7 +51,9 @@ class Records {
  * @return {object}          json object
  */
   static async getRecords(request, response) {
-    const records = await RecordsModel.getAllRecords(request.route.path.substr(1));
+    let type = request.route.path.substr(1);
+    if (type === 'interventions') type = 'intervention';
+    const records = await RecordsModel.getAllRecords(type);
     response.status(200).json({
       status: 200,
       data: records,

--- a/server/routes/records.js
+++ b/server/routes/records.js
@@ -12,6 +12,7 @@ const router = express.Router();
 router.post('/red-flags', Records.createRecord);
 router.post('/interventions', Records.createRecord);
 router.get('/red-flags', Records.getRecords);
+router.get('/interventions', Records.getRecords);
 router.get('/red-flags/:id', getRecordType, validateUrl, Records.getSpecificRecord);
 router.patch('/red-flags/:id/location', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/red-flags/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);

--- a/server/spec/routes.spec.js
+++ b/server/spec/routes.spec.js
@@ -20,6 +20,17 @@ describe('Server', () => {
         });
     });
   });
+  describe('GET /api/v1/interventions', () => {
+    it('should return 200 for successful request', async () => {
+      await supertest(appInstance)
+        .get('/api/v1/interventions')
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(200);
+        });
+    });
+  });
 
   describe('POST /api/v1/red-flags', () => {
     const data = {


### PR DESCRIPTION
#### What does this PR do?
This PR adds API functionality to get all intervention records
#### Description of task to be completed?
* Add api endpoint to get all intervention records
* Write tests for the endpoint
#### How can this be manually tested?
* Clone the repository
* Checkout to branch `ft-get-intervention-records-162636950`
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162636950
#### Screenshots (If available)
N/A
