### PR TITLE
#162638643 Add API endpoint to edit the status of a red flag

### DIFF
--- a/server/controllers/records.js
+++ b/server/controllers/records.js
@@ -84,9 +84,19 @@ class Records {
     const data = {};
     if (request.recordField === 'comment') {
       data.comment = request.content;
-    } else {
+    } else if (request.recordField === 'location') {
       data.location = request.content;
+    } else {
+      data.status = request.content;
+      if (data.status !== 'draft' && data.status !== 'resolved'
+        && data.status !== 'under investigation' && data.status !== 'rejected') {
+        return response.status(400).json({
+          status: 400,
+          error: 'Status can only be updated as draft, resolved, under investigation or rejected',
+        });
+      }
     }
+
     await RecordsModel.updateField(request.params.id, data);
     const message = `Updated ${request.recordType} ${request.recordField}`;
     response.status(200).json({

--- a/server/helper.js
+++ b/server/helper.js
@@ -127,13 +127,16 @@ export const getRecordType = async (request, response, next) => {
 };
 export const validateRecordType = async (request, response, next) => {
   if ((request.recordField === 'location' && !request.body.location)
-    || (request.recordField === 'comment' && !request.body.comment)) {
+    || (request.recordField === 'comment' && !request.body.comment)
+    || (request.recordField === 'status' && !request.body.status)) {
     return response.status(422).json({
       status: 422,
       error: 'Invalid data',
     });
   }
-  request.content = (request.body.comment) ? request.body.comment : request.body.location;
+  if (request.recordField === 'location') request.content = request.body.location;
+  else if (request.recordField === 'comment') request.content = request.body.comment;
+  else if (request.recordField === 'status') request.content = request.body.status;
   next();
 };
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -58,7 +58,7 @@ class Auth {
    */
   static verifyAdmin(request, response, next) {
     const { isadmin } = request;
-    if (isadmin !== true) {
+    if (isadmin !== 'true') {
       return response.status(500).json({
         status: 500,
         auth: false,

--- a/server/models/setup_test_db.js
+++ b/server/models/setup_test_db.js
@@ -33,8 +33,12 @@ const createTableRecords = `CREATE TABLE records(
   )`;
 
 const query = `INSERT into ireporter_users(
+  email, firstname, lastname, othernames, username, registered, phonenumber, password, isadmin) VALUES(
+  'jessam@joyson.com', 'john', 'doe', 'jaime', 'lannister', 'today', '123456789', '${hashedPwd}', 'true')`;
+
+const query8 = `INSERT into ireporter_users(
   email, firstname, lastname, othernames, username, registered, phonenumber, password) VALUES(
-  'jessam@joyson.com', 'john', 'doe', 'jaime', 'lannister', 'today', '123456789', '${hashedPwd}')`;
+  'jessam1@joyson.com', 'john', 'doe', 'jaime', 'lannister', 'today', '123456789', '${hashedPwd}')`;
 
 const query1 = `INSERT into records(
   createdOn, createdBy, type, location, comment, title) VALUES(
@@ -66,8 +70,11 @@ pool.query(createTableUsers).then((res) => {
           pool.query(query3).then((res) => {
             pool.query(query4).then((res) => {
               pool.query(query5).then((res) => {
-                  pool.query(query7).then((res) => {
-                pool.query(query6).then(res => console.log(res));
+                pool.query(query7).then((res) => {
+                  pool.query(query8).then((res) => {
+                    pool.query(query6).then(res => console.log(res));
+                  });
+                });
               });
             });
           });
@@ -75,5 +82,4 @@ pool.query(createTableUsers).then((res) => {
       });
     });
   });
-});
 });

--- a/server/routes/records.js
+++ b/server/routes/records.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import Records from '../controllers/records';
+import Auth from '../middleware/auth';
 import {
   validateUrl,
   validateRecordType,
@@ -16,6 +17,7 @@ router.get('/interventions', Records.getRecords);
 router.get('/red-flags/:id', getRecordType, validateUrl, Records.getSpecificRecord);
 router.get('/interventions/:id', getRecordType, validateUrl, Records.getSpecificRecord);
 router.patch('/red-flags/:id/location', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
+router.patch('/red-flags/:id/status', Auth.verifyAdmin, getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/red-flags/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.delete('/red-flags/:id', getRecordType, validateUrl, validateRecordField, Records.deleteRecord);
 

--- a/server/spec/routes.spec.js
+++ b/server/spec/routes.spec.js
@@ -3,6 +3,7 @@ import 'babel-polyfill';
 import app from '../../server';
 
 const token = process.env.TEST_TOKEN;
+const adminToken = process.env.TEST_TOKEN_ADMIN;
 
 describe('Server', () => {
   const appInstance = app.listen();
@@ -365,6 +366,46 @@ describe('Server', () => {
         });
     });
   });
+
+  describe('PATCH /api/v1/red-flags/:id/status', () => {
+    const data = {
+      status: 'Another Test status',
+    };
+
+    it('should return 422 for invalid data', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/red-flags/2/status')
+        .send()
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(422);
+        });
+    });
+
+    it('should return 404 for record not found', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/red-flags/100/status')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(404);
+        });
+    });
+
+    it('should return 400 for invalid url', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/red-flags/gbiy/status')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+  });
+
 
   describe('DELETE /api/v1/red-flags/:id', () => {
     it('should return 200 for successful request', async () => {


### PR DESCRIPTION
#### What does this PR do?
This PR adds an API endpoint to edit the status of a red-flag record
#### Description of task to be completed?
* Add endpoint to edit red flag status
* write tests for the endpoint
#### How should this be manually tested?
* Clone the repository
* Checkout to branch `ft-edit-red-flag-status-162638643`
* Send a patch request to `api/v1/red-flags/:id/status with a valid admin token
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162638643
#### Screenshots
N/A
