### PR TITLE
#162651205 Add API endpoint to edit the comment of an intervention record

### DIFF
--- a/server/models/setup_test_db.js
+++ b/server/models/setup_test_db.js
@@ -59,7 +59,7 @@ const query5 = `INSERT into records(
 const query7 = `INSERT into records(
   createdOn, createdBy, type, location, comment, title) VALUES(
   'today', '1', 'intervention', 'Lagos', 'Test comment', 'Test title')`;
-const query6 = 'select id from records';
+const query6 = 'select id, type from records';
 
 
 pool.query(createTableUsers).then((res) => {

--- a/server/routes/records.js
+++ b/server/routes/records.js
@@ -19,6 +19,7 @@ router.get('/interventions/:id', getRecordType, validateUrl, Records.getSpecific
 router.patch('/red-flags/:id/location', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/red-flags/:id/status', Auth.verifyAdmin, getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/red-flags/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
+router.patch('/interventions/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.delete('/red-flags/:id', getRecordType, validateUrl, validateRecordField, Records.deleteRecord);
 
 module.exports = router;

--- a/server/spec/routes.spec.js
+++ b/server/spec/routes.spec.js
@@ -367,6 +367,56 @@ describe('Server', () => {
     });
   });
 
+  describe('PATCH /api/v1/interventions/:id/comment', () => {
+    const data = {
+      comment: 'Another Test comment',
+    };
+
+    it('should return 200 for successful request', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/4/comment')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(200);
+        });
+    });
+
+    it('should return 422 for invalid data', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/4/comment')
+        .send()
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(422);
+        });
+    });
+
+    it('should return 404 for record not found', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/100/comment')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(404);
+        });
+    });
+
+    it('should return 400 for invalid url', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/gbiy/comment')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+  });
+
   describe('PATCH /api/v1/red-flags/:id/status', () => {
     const data = {
       status: 'Another Test status',


### PR DESCRIPTION
#### What does this PR do?
This PR adds an API endpoint to edit the comment of an intervention record
#### Description of task to be completed?
* Add endpoint to edit a specific intervention record's comment
* Write tests for the endpoint
#### How should this be manually tested?
* Clone the repository
* Checkout to branch `ft-edit-intervention-comment-162651205`
* Send a patch request to `api/v1/intervention/:id/comment with a valid token
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162651205
#### Screenshots (If applicable)
N/A

