### PR TITLE
#162652889 Add API endpoint to edit the status of an intervention record

### DIFF
--- a/server/routes/records.js
+++ b/server/routes/records.js
@@ -18,6 +18,7 @@ router.get('/red-flags/:id', getRecordType, validateUrl, Records.getSpecificReco
 router.get('/interventions/:id', getRecordType, validateUrl, Records.getSpecificRecord);
 router.patch('/red-flags/:id/location', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/red-flags/:id/status', Auth.verifyAdmin, getRecordType, validateUrl, validateRecordType, Records.updateRecord);
+router.patch('/interventions/:id/status', Auth.verifyAdmin, getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/red-flags/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/interventions/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.delete('/red-flags/:id', getRecordType, validateUrl, validateRecordField, Records.deleteRecord);


### PR DESCRIPTION
#### What does this PR do?
This PR adds an API endpoint to edit the status of an intervention record
#### Description of task to be completed?
* Add endpoint to edit a specific intervention record's status
#### How should this be manually tested?
* Clone the repository
* Checkout to branch `ft-edit-intervention-status-162652889`
* Send a patch request to `api/v1/intervention/:id/status with a valid token
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162652889
#### Screenshots (If applicable)
N/A

