### PR TITLE
#162685281 Add API endpoint to delete intervention record endpoint

### DIFF
--- a/server/controllers/records.js
+++ b/server/controllers/records.js
@@ -27,13 +27,11 @@ class Records {
     const images = (request.body.images) ? request.body.images : '';
     const videos = (request.body.videos) ? request.body.videos : '';
     const createdBy = (request.body.createdby) ? request.body.createdby : request.userid;
-
     const data = {
       title, createdOn, type, location, comment, images, videos, createdBy,
     };
 
     const message = `Created ${type} record`;
-
     const id = await RecordsModel.createRecord(data);
     return response.status(201).json({
       status: 201,
@@ -117,7 +115,7 @@ class Records {
   static async deleteRecord(request, response) {
     RecordsModel.deleteRecord(request.params.id);
     const message = `${request.recordType} record has been deleted`;
-    response.status(200).json({
+    return response.status(200).json({
       status: 200,
       data: [{
         id: request.params.id,

--- a/server/helper.js
+++ b/server/helper.js
@@ -96,7 +96,7 @@ export const fieldsAreNotLetters = async (requestBody) => {
 export const dateString = () => {
   // set date up
   const dateObj = new Date();
-  return `${dateObj.getFullYear()} / ${(dateObj.getMonth() + 1)} / ${dateObj.getDate()}`;
+  return `${dateObj.getFullYear()}/${(dateObj.getMonth() + 1)}/${dateObj.getDate()}`;
 };
 
 export const validateUrl = async (request, response, next) => {

--- a/server/routes/records.js
+++ b/server/routes/records.js
@@ -23,5 +23,6 @@ router.patch('/interventions/:id/status', Auth.verifyAdmin, getRecordType, valid
 router.patch('/red-flags/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.patch('/interventions/:id/comment', getRecordType, validateUrl, validateRecordType, Records.updateRecord);
 router.delete('/red-flags/:id', getRecordType, validateUrl, validateRecordField, Records.deleteRecord);
+router.delete('/interventions/:id', getRecordType, validateUrl, validateRecordField, Records.deleteRecord);
 
 module.exports = router;

--- a/server/spec/routes.spec.js
+++ b/server/spec/routes.spec.js
@@ -469,8 +469,22 @@ describe('Server', () => {
 
   describe('PATCH /api/v1/red-flags/:id/status', () => {
     const data = {
-      status: 'Another Test status',
+      status: 'resolved',
     };
+    const incorrectData = {
+      status: 'any other status',
+    }
+
+    it('should return 200 for successful request', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/red-flags/1/status')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(200);
+        });
+    });
 
     it('should return 422 for invalid data', async () => {
       await supertest(appInstance)
@@ -506,6 +520,58 @@ describe('Server', () => {
     });
   });
 
+  describe('PATCH /api/v1/interventions/:id/status', () => {
+    const data = {
+      status: 'rejected',
+    };
+    const incorrectData = {
+      status: 'Another Test intervention',
+    };
+
+    it('should return 200 for successful request', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/4/status')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(200);
+        });
+    });
+
+    it('should return 422 for invalid data', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/4/status')
+        .send()
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(422);
+        });
+    });
+
+    it('should return 404 for record not found', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/100/status')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(404);
+        });
+    });
+
+    it('should return 400 for invalid url', async () => {
+      await supertest(appInstance)
+        .patch('/api/v1/interventions/gbiy/status')
+        .send(data)
+        .set('content-type', 'application/json')
+        .set('x-access-token', adminToken)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+  });
 
   describe('DELETE /api/v1/red-flags/:id', () => {
     it('should return 200 for successful request', async () => {
@@ -528,6 +594,34 @@ describe('Server', () => {
     it('should return 400 for invalid url', async () => {
       await supertest(appInstance)
         .delete('/api/v1/red-flags/ugi')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(400);
+        });
+    });
+  });
+
+  describe('DELETE /api/v1/interventions/:id', () => {
+    it('should return 200 for successful request', async () => {
+      await supertest(appInstance)
+        .delete('/api/v1/interventions/5')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(200);
+        });
+    });
+
+    it('should return 404 for record not found', async () => {
+      await supertest(appInstance)
+        .delete('/api/v1/interventions/100')
+        .set('x-access-token', token)
+        .expect((res) => {
+          expect(res.statusCode).toBe(404);
+        });
+    });
+    it('should return 400 for invalid url', async () => {
+      await supertest(appInstance)
+        .delete('/api/v1/interventions/ugi')
         .set('x-access-token', token)
         .expect((res) => {
           expect(res.statusCode).toBe(400);


### PR DESCRIPTION
#### What does this PR do?
* This PR adds an API endpoint to delete an intervention record
#### Description of task to be completed?
* Add endpoint to delete a specific intervention record
#### How should this be manually tested?
* Clone the repository
* Checkout to branch ft-delete-intervention-162685281
* Send a DELETE request to `api/v1/interventions/:id with a valid token
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162685281
#### Screenshots (If applicable)
N/A